### PR TITLE
feat: Attempt to make deploy only happen on master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
     needs: [tests, build-docker-image]
+    # https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions
+    if: github.ref == 'refs/heads/master'
     # https://medium.com/ryanjang-devnotes/ci-cd-hands-on-github-actions-docker-hub-aws-ec2-ba09f80297e1
     steps:
       - name: Extract commit hash


### PR DESCRIPTION
# Work

After noticing that the deploy job should run on all branches, this PR attempts to make it conditional and happen only on `master`.

# Tests

The CI run for this branch did not run the `deploy` step:

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/96476c8a-028b-4f94-a616-19ea2bf01109)

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/e0c28732-1f4b-4d46-864e-3cfac98c954d)


# Future work
