### PR TITLE
feat: Use custom logger for pgx processes

### DIFF
--- a/cmd/users/internal/config.go
+++ b/cmd/users/internal/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/KnoblauchPilze/user-service/pkg/db"
 	"github.com/KnoblauchPilze/user-service/pkg/rest"
+	"github.com/labstack/gommon/log"
 	"github.com/spf13/viper"
 )
 
@@ -64,6 +65,7 @@ func defaultConf() Configuration {
 			Port:                5432,
 			Name:                "db_user_service",
 			ConnectionsPoolSize: 1,
+			LogLevel:            log.DEBUG,
 		},
 	}
 }

--- a/cmd/users/internal/config_test.go
+++ b/cmd/users/internal/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/KnoblauchPilze/user-service/pkg/rest"
+	"github.com/labstack/gommon/log"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,6 +72,14 @@ func TestDefaultConfig_Database_DoesNotDefinePassword(t *testing.T) {
 	conf := defaultConf()
 
 	assert.Equal("", conf.Database.Password)
+}
+
+func TestDefaultConfig_Database_UsesDebugLogLevel(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := defaultConf()
+
+	assert.Equal(log.DEBUG, conf.Database.LogLevel)
 }
 
 type mockConfigurationParser struct {

--- a/pkg/db/config.go
+++ b/pkg/db/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/labstack/gommon/log"
 )
 
 type Config struct {
@@ -16,6 +17,7 @@ type Config struct {
 	User                string
 	Password            string
 	ConnectionsPoolSize uint
+	LogLevel            log.Lvl
 }
 
 // https://github.com/jackc/pgx/blob/60a01d044a5b3f65b9eea866954fdeea1e7d3f00/pgxpool/pool.go#L286
@@ -38,11 +40,10 @@ func (c Config) toConnPoolConfig() (*pgxpool.Config, error) {
 		return nil, err
 	}
 
+	// TODO: How to make sure that the request id is logged?
 	conf.ConnConfig.Tracer = &tracelog.TraceLog{
-		// TODO: How to make sure that the request id is logged?
-		Logger: &pgxLoggerImpl{},
-		// TODO: Make this configurable
-		LogLevel: tracelog.LogLevelTrace,
+		Logger:   new(true),
+		LogLevel: toTracelogLevel(c.LogLevel),
 	}
 
 	return conf, nil

--- a/pkg/db/connection_pool.go
+++ b/pkg/db/connection_pool.go
@@ -74,17 +74,11 @@ func (c *connectionPoolImpl) StartTransaction(ctx context.Context) (Transaction,
 }
 
 func (c *connectionPoolImpl) Query(ctx context.Context, sql string, arguments ...any) Rows {
-	log := logger.GetRequestLogger(ctx)
-	log.Debugf("Query: %s (%d)", sql, len(arguments))
-
 	rows, err := c.pool.Query(ctx, sql, arguments...)
 	return newRows(rows, err)
 }
 
 func (c *connectionPoolImpl) Exec(ctx context.Context, sql string, arguments ...any) (int, error) {
-	log := logger.GetRequestLogger(ctx)
-	log.Debugf("Exec: %s (%d)", sql, len(arguments))
-
 	tag, err := c.pool.Exec(ctx, sql, arguments...)
 	return int(tag.RowsAffected()), err
 }

--- a/pkg/db/logger.go
+++ b/pkg/db/logger.go
@@ -3,38 +3,115 @@ package db
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/KnoblauchPilze/user-service/pkg/logger"
 	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
 )
 
-type pgxLoggerImpl struct{}
+type pgxLoggerImpl struct {
+	ignoreUnknownMessages bool
+	logger                echo.Logger
+}
+
+const pgxPrefixString = "pgx"
+const pgxPrepareMessage = "Prepare"
+const pgxQueryMessage = "Query"
+
+func new(ignoreUnknownMessages bool) tracelog.Logger {
+	return &pgxLoggerImpl{
+		ignoreUnknownMessages: ignoreUnknownMessages,
+		logger:                logger.New(pgxPrefixString),
+	}
+}
 
 func (l *pgxLoggerImpl) Log(ctx context.Context, level tracelog.LogLevel, msg string, data map[string]any) {
-	outMsg := fmt.Sprintf("pgx %s %s", msg, flattenMap(data))
+	var outMsg string
+	knownMessage := true
+
+	switch msg {
+	case pgxPrepareMessage:
+		outMsg = prepareSqlMessage(msg, data)
+	case pgxQueryMessage:
+		outMsg = prepareSqlMessage(msg, data)
+	default:
+		knownMessage = false
+	}
+
+	if !knownMessage && !l.ignoreUnknownMessages {
+		outMsg = fmt.Sprintf("%s %s", msg, flattenMap(data))
+	}
+
+	if outMsg == "" {
+		return
+	}
 
 	switch level {
 	case tracelog.LogLevelTrace:
-		logger.Tracef(outMsg)
+		l.logger.Debugf(outMsg)
 	case tracelog.LogLevelDebug:
-		logger.Debugf(outMsg)
+		l.logger.Debugf(outMsg)
 	case tracelog.LogLevelInfo:
-		logger.Infof(outMsg)
+		l.logger.Infof(outMsg)
 	case tracelog.LogLevelWarn:
-		logger.Warnf(outMsg)
+		l.logger.Warnf(outMsg)
 	case tracelog.LogLevelError:
-		logger.Errorf(outMsg)
-	case tracelog.LogLevelNone:
-		logger.Tracef(outMsg)
+		l.logger.Errorf(outMsg)
+	}
+}
+
+func toTracelogLevel(level log.Lvl) tracelog.LogLevel {
+	switch level {
+	case log.DEBUG:
+		return tracelog.LogLevelDebug
+	case log.INFO:
+		return tracelog.LogLevelInfo
+	case log.WARN:
+		return tracelog.LogLevelWarn
+	case log.ERROR:
+		return tracelog.LogLevelError
+	default:
+		return tracelog.LogLevelNone
 	}
 }
 
 func flattenMap(data map[string]interface{}) string {
+	// Order of maps is not deterministic
+	var keys []string
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var values []string
-	for key, value := range data {
+	for _, key := range keys {
+		value := data[key]
 		values = append(values, fmt.Sprintf("%v: %v", key, value))
 	}
 
 	return strings.Join(values, " ")
+}
+
+func prepareSqlMessage(message string, data map[string]interface{}) string {
+	out := message
+
+	sql, ok := data["sql"]
+	if ok {
+		out += fmt.Sprintf(" %v", sql)
+	}
+
+	args, ok := data["args"]
+	if ok {
+		out += fmt.Sprintf(" args=%v", args)
+	}
+
+	duration, ok := data["time"]
+	if ok {
+		out += fmt.Sprintf(", time=%v", duration)
+	}
+
+	return out
 }

--- a/pkg/db/logger.go
+++ b/pkg/db/logger.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/KnoblauchPilze/user-service/pkg/logger"
+	"github.com/jackc/pgx/v5/tracelog"
+)
+
+type pgxLoggerImpl struct{}
+
+func (l *pgxLoggerImpl) Log(ctx context.Context, level tracelog.LogLevel, msg string, data map[string]any) {
+	outMsg := fmt.Sprintf("pgx %s %s", msg, flattenMap(data))
+
+	switch level {
+	case tracelog.LogLevelTrace:
+		logger.Tracef(outMsg)
+	case tracelog.LogLevelDebug:
+		logger.Debugf(outMsg)
+	case tracelog.LogLevelInfo:
+		logger.Infof(outMsg)
+	case tracelog.LogLevelWarn:
+		logger.Warnf(outMsg)
+	case tracelog.LogLevelError:
+		logger.Errorf(outMsg)
+	case tracelog.LogLevelNone:
+		logger.Tracef(outMsg)
+	}
+}
+
+func flattenMap(data map[string]interface{}) string {
+	var values []string
+	for key, value := range data {
+		values = append(values, fmt.Sprintf("%v: %v", key, value))
+	}
+
+	return strings.Join(values, " ")
+}

--- a/pkg/db/logger_test.go
+++ b/pkg/db/logger_test.go
@@ -1,0 +1,307 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToTraceLogLevel(t *testing.T) {
+	assert := assert.New(t)
+
+	type testCase struct {
+		in       log.Lvl
+		expected tracelog.LogLevel
+	}
+
+	testCases := map[string]testCase{
+		"debug": {in: log.DEBUG, expected: tracelog.LogLevelDebug},
+		"info":  {in: log.INFO, expected: tracelog.LogLevelInfo},
+		"warn":  {in: log.WARN, expected: tracelog.LogLevelWarn},
+		"error": {in: log.ERROR, expected: tracelog.LogLevelError},
+		"off":   {in: log.OFF, expected: tracelog.LogLevelNone},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := toTracelogLevel(testCase.in)
+
+			assert.Equal(testCase.expected, actual)
+		})
+	}
+}
+
+func TestFlattenMap(t *testing.T) {
+	assert := assert.New(t)
+
+	type testCase struct {
+		in       map[string]interface{}
+		expected string
+	}
+
+	testCases := []testCase{
+		{in: nil, expected: ""},
+		{in: map[string]interface{}{"key": 1}, expected: "key: 1"},
+		{in: map[string]interface{}{"key": []float32{1.2, -4.5}}, expected: "key: [1.2 -4.5]"},
+		{in: map[string]interface{}{"key": "value", "key2": 36}, expected: "key: value key2: 36"},
+		{in: map[string]interface{}{"key": -59.9, "key2": "haha", "key3": 72}, expected: "key: -59.9 key2: haha key3: 72"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			actual := flattenMap(testCase.in)
+
+			assert.Equal(testCase.expected, actual)
+		})
+	}
+}
+
+var date = time.Date(2024, 04, 01, 11, 8, 47, 651387237, time.UTC)
+
+func TestPrepareSqlMessage(t *testing.T) {
+	assert := assert.New(t)
+
+	type testCase struct {
+		msg      string
+		args     map[string]interface{}
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			msg:      "dummy",
+			args:     map[string]interface{}{},
+			expected: "dummy",
+		},
+		{
+			msg: "Query",
+			args: map[string]interface{}{
+				"sql": "select * from table",
+			},
+			expected: "Query select * from table",
+		},
+		{
+			msg: "Query",
+			args: map[string]interface{}{
+				"args": []interface{}{"aa-ee", 36},
+			},
+			expected: "Query args=[aa-ee 36]",
+		},
+		{
+			msg: "Prepare",
+			args: map[string]interface{}{
+				"time": date,
+			},
+			expected: "Prepare, time=2024-04-01 11:08:47.651387237 +0000 UTC",
+		},
+		{
+			msg: "Prepare",
+			args: map[string]interface{}{
+				"sql":  "select * from table where id = $1",
+				"args": []interface{}{27, "aa-ee"},
+			},
+			expected: "Prepare select * from table where id = $1 args=[27 aa-ee]",
+		},
+		{
+			msg: "Query",
+			args: map[string]interface{}{
+				"sql":  "select * from table where id = $1",
+				"time": date,
+			},
+			expected: "Query select * from table where id = $1, time=2024-04-01 11:08:47.651387237 +0000 UTC",
+		},
+		{
+			msg: "Query",
+			args: map[string]interface{}{
+				"args": []interface{}{27, "aa-ee"},
+				"time": date,
+			},
+			expected: "Query args=[27 aa-ee], time=2024-04-01 11:08:47.651387237 +0000 UTC",
+		},
+		{
+			msg: "Query",
+			args: map[string]interface{}{
+				"sql":  "select * from table where id = $1 and name = $2",
+				"args": []interface{}{27, "aa-ee"},
+				"time": date,
+			},
+			expected: "Query select * from table where id = $1 and name = $2 args=[27 aa-ee], time=2024-04-01 11:08:47.651387237 +0000 UTC",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			actual := prepareSqlMessage(testCase.msg, testCase.args)
+			assert.Equal(testCase.expected, actual)
+		})
+	}
+}
+
+type mockEchoLogger struct {
+	echo.Logger
+
+	debugCalled int
+	infoCalled  int
+	warnCalled  int
+	errorCalled int
+
+	format string
+	args   []interface{}
+}
+
+func TestPgxLoggerImpl_Log_Trace(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelTrace, "message", map[string]any{"toto": 1})
+
+	assert.Equal(1, m.debugCalled)
+	assert.Equal("message toto: 1", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func TestPgxLoggerImpl_Log_Debug(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelDebug, "message", map[string]any{"toto": 1})
+
+	assert.Equal(1, m.debugCalled)
+	assert.Equal("message toto: 1", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func TestPgxLoggerImpl_Log_Info(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelInfo, "message", map[string]any{"toto": 1})
+
+	assert.Equal(1, m.infoCalled)
+	assert.Equal("message toto: 1", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func TestPgxLoggerImpl_Log_Warn(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelWarn, "message", map[string]any{"toto": 1})
+
+	assert.Equal(1, m.warnCalled)
+	assert.Equal("message toto: 1", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func TestPgxLoggerImpl_Log_Error(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelError, "message", map[string]any{"toto": 1})
+
+	assert.Equal(1, m.errorCalled)
+	assert.Equal("message toto: 1", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func TestPgxLoggerImpl_Log_None(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		logger: m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelNone, "message", map[string]any{"toto": 1})
+
+	assert.Equal(0, m.debugCalled)
+	assert.Equal(0, m.infoCalled)
+	assert.Equal(0, m.warnCalled)
+	assert.Equal(0, m.errorCalled)
+}
+
+func TestPgxLoggerImpl_WhenMessageIsUnknownAndSetToIgnore_ExpectNoLog(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		ignoreUnknownMessages: true,
+		logger:                m,
+	}
+
+	l.Log(context.Background(), tracelog.LogLevelError, "message", map[string]any{"toto": 1})
+
+	assert.Equal(0, m.debugCalled)
+	assert.Equal(0, m.infoCalled)
+	assert.Equal(0, m.warnCalled)
+	assert.Equal(0, m.errorCalled)
+}
+
+func TestPgxLoggerImpl_WhenMessageIsKnownAndSetToIgnore_ExpectFormattedLog(t *testing.T) {
+	assert := assert.New(t)
+
+	m := &mockEchoLogger{}
+	l := pgxLoggerImpl{
+		ignoreUnknownMessages: true,
+		logger:                m,
+	}
+
+	args := map[string]interface{}{
+		"sql":  "select * from table where id = $1",
+		"args": []interface{}{"aa-ee"},
+	}
+	l.Log(context.Background(), tracelog.LogLevelInfo, "Query", args)
+
+	assert.Equal(1, m.infoCalled)
+	assert.Equal("Query select * from table where id = $1 args=[aa-ee]", m.format)
+	assert.Equal(0, len(m.args))
+}
+
+func (m *mockEchoLogger) Debugf(format string, args ...interface{}) {
+	m.debugCalled++
+	m.format = format
+	m.args = append(m.args, args...)
+}
+
+func (m *mockEchoLogger) Infof(format string, args ...interface{}) {
+	m.infoCalled++
+	m.format = format
+	m.args = append(m.args, args...)
+}
+
+func (m *mockEchoLogger) Warnf(format string, args ...interface{}) {
+	m.warnCalled++
+	m.format = format
+	m.args = append(m.args, args...)
+}
+
+func (m *mockEchoLogger) Errorf(format string, args ...interface{}) {
+	m.errorCalled++
+	m.format = format
+	m.args = append(m.args, args...)
+}

--- a/pkg/db/transaction.go
+++ b/pkg/db/transaction.go
@@ -27,18 +27,12 @@ func (t *transactionImpl) Close(ctx context.Context) {
 }
 
 func (t *transactionImpl) Query(ctx context.Context, sql string, arguments ...interface{}) Rows {
-	log := logger.GetRequestLogger(ctx)
-	log.Debugf("Query: %s (%d)", sql, len(arguments))
-
 	rows, err := t.tx.Query(ctx, sql, arguments...)
 	t.updateErrorStatus(err)
 	return newRows(rows, err)
 }
 
 func (t *transactionImpl) Exec(ctx context.Context, sql string, arguments ...interface{}) (int, error) {
-	log := logger.GetRequestLogger(ctx)
-	log.Debugf("Exec: %s (%d)", sql, len(arguments))
-
 	tag, err := t.tx.Exec(ctx, sql, arguments...)
 	t.updateErrorStatus(err)
 	return int(tag.RowsAffected()), err


### PR DESCRIPTION
# Work

The `pgx` package offers some logging/tracing possibilities which might be interesting to leverage.

The approach relies on the [TraceLog](https://github.com/jackc/pgx/blob/60a01d044a5b3f65b9eea866954fdeea1e7d3f00/tracelog/tracelog.go#L122) struct which takes in argument a [Logger](https://github.com/jackc/pgx/blob/60a01d044a5b3f65b9eea866954fdeea1e7d3f00/tracelog/tracelog.go#L50) interface and can be passed on to the [ConnConfig](https://github.com/jackc/pgx/blob/master/conn.go#L25).

According to [this SO post](https://stackoverflow.com/questions/64504879/how-to-log-queries-with-pgx) it is as simple as setting the `Tracer` field in the connection config and we're good to go.

From there, it's a simple question of providing an implementation of the `Logger` interface, which this PR brings. We can then remove the:
```go
log := logger.GetRequestLogger(ctx)
log.Debugf("Exec: %s (%d)", sql, len(arguments))
```

From our code and rely on `pgx` to do the logging. This looks like so:

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/644d14d8-1dbe-4982-9b80-3b6789fd1216)

It seems like pgx is using some sort of structured logging which we could leverage. The first approach is a bit verbose so we decided to strip the known messages to keep only what is relevant for us (the queries, the arguments and the timing). This gives this version:

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/aa3daa23-036d-4084-adcd-70f69d674839)

# Tests
* Added some tests under [pkg/db/logger_test.go](pkg/db/logger_test.go) to verify that we strip the messages correctly and ignore the unknown ones and generally that the logging does what we expect it to do.
* Added a test for the default configuration under [cmd/users/internal/config_test.go](cmd/users/internal/config_test.go) to verify that the default log level is set to `DEBUG`.

# Future work

For now the whole `connection_poll` gets the same logger which is not the logger of the request. This means that we can't effectively trace the logs of a single request effectively.

Changing this might require to move away from the `connection_pool` and instead instantiate connections ourselves. Or at least modify the [QueryTracer](https://github.com/jackc/pgx/blob/60a01d044a5b3f65b9eea866954fdeea1e7d3f00/conn.go#L74) attached to each connection when getting one from the pool.

The problem is that this would also prevent us from using the `pool.Query(...)` syntax but rather use something like [AcquireFunc](https://github.com/jackc/pgx/blob/60a01d044a5b3f65b9eea866954fdeea1e7d3f00/pgxpool/pool.go#L529C16-L529C27):
```go
f := func(conn *pgx.Conn) error {
  conn.QueryTracer = ...
  rows, err := conn.Query(...)
  if err != nil {
    return err
  }
  defer rows.Close()
  ...
  return err
}

err := pool.AcquireFunc(ctx, f)
```

This might be done in a later step, for now the logging is sufficient.