### PR TITLE
feat: Ground work for login and logout endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,27 +375,37 @@ curl -X GET -H "Content-Type: application/json" -H 'X-Api-Key: 2da3e9ec-7299-473
 
 ## Query non existing user
 ```bash
-curl -X GET -H "Content-Type: application/json" -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/4f26321f-d0ea-46a3-83dd-6aa1c6053aae | jq
+curl -X GET -H 'Content-Type: application/json' -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/4f26321f-d0ea-46a3-83dd-6aa1c6053aae | jq
 ```
 
 ## Query without API key
 ```bash
-curl -X GET -H "Content-Type: application/json" http://localhost:60001/v1/users/4f26321f-d0ea-46a3-83dd-6aa1c6053aae | jq
+curl -X GET -H 'Content-Type: application/json' http://localhost:60001/v1/users/4f26321f-d0ea-46a3-83dd-6aa1c6053aae | jq
 ```
 
 ## List users
 ```bash
-curl -X GET -H "Content-Type: application/json" -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users | jq
+curl -X GET -H 'Content-Type: application/json' '-H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users | jq
 ```
 
 ## Patch existing user
 ```bash
-curl -X PATCH -H "Content-Type: application/json" -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/0463ed3d-bfc9-4c10-b6ee-c223bbca0fab -d '{"email":"test-user@real-provider.com","password":"strong-password"}'| jq
+curl -X PATCH -H 'Content-Type: application/json' -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/0463ed3d-bfc9-4c10-b6ee-c223bbca0fab -d '{"email":"test-user@real-provider.com","password":"strong-password"}'| jq
 ```
 
 ## Delete user
 ```bash
-curl -X DELETE -H "Content-Type: application/json" -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/0463ed3d-bfc9-4c10-b6ee-c223bbca0fab | jq
+curl -X DELETE -H 'Content-Type: application/json' -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/0463ed3d-bfc9-4c10-b6ee-c223bbca0fab | jq
+```
+
+## Login a user
+```bash
+curl -X POST -H 'Content-Type: application/json' http://localhost:60001/v1/users/sessions/4f26321f-d0ea-46a3-83dd-6aa1c6053aaf | jq
+```
+
+## Logout a user
+```bash
+curl -X DELETE -H 'Content-Type: application/json' -H 'X-Api-Key: 2da3e9ec-7299-473a-be0f-d722d870f51a' http://localhost:60001/v1/users/sessions/4f26321f-d0ea-46a3-83dd-6aa1c6053aaf | jq
 ```
 
 ## Build the docker container

--- a/internal/users/controller/users.go
+++ b/internal/users/controller/users.go
@@ -169,7 +169,6 @@ func logoutUser(c echo.Context, service service.UserService) error {
 	}
 
 	err = service.Logout(c.Request().Context(), id)
-	// TODO: Better error handling?
 	if err != nil {
 		if errors.IsErrorWithCode(err, db.NoMatchingSqlRows) {
 			return c.JSON(http.StatusNotFound, "No such user")

--- a/internal/users/controller/users.go
+++ b/internal/users/controller/users.go
@@ -151,7 +151,10 @@ func loginUser(c echo.Context, service service.UserService) error {
 
 	out, err := service.Login(c.Request().Context(), id)
 	if err != nil {
-		// TODO: Better error handling?
+		if errors.IsErrorWithCode(err, db.NoMatchingSqlRows) {
+			return c.JSON(http.StatusNotFound, "No such user")
+		}
+
 		return c.JSON(http.StatusInternalServerError, err)
 	}
 

--- a/internal/users/controller/users_test.go
+++ b/internal/users/controller/users_test.go
@@ -63,10 +63,10 @@ func TestUserEndpoints_GeneratesExpectedRoutes(t *testing.T) {
 	}
 
 	assert.Equal(4, len(actualRoutes))
-	assert.Equal(3, actualRoutes[http.MethodPost])
+	assert.Equal(2, actualRoutes[http.MethodPost])
 	assert.Equal(2, actualRoutes[http.MethodGet])
 	assert.Equal(1, actualRoutes[http.MethodPatch])
-	assert.Equal(1, actualRoutes[http.MethodDelete])
+	assert.Equal(2, actualRoutes[http.MethodDelete])
 }
 
 func TestCreateUser_WhenBindFails_SetsStatusToBadRequest(t *testing.T) {

--- a/internal/users/controller/users_test.go
+++ b/internal/users/controller/users_test.go
@@ -63,7 +63,7 @@ func TestUserEndpoints_GeneratesExpectedRoutes(t *testing.T) {
 	}
 
 	assert.Equal(4, len(actualRoutes))
-	assert.Equal(1, actualRoutes[http.MethodPost])
+	assert.Equal(3, actualRoutes[http.MethodPost])
 	assert.Equal(2, actualRoutes[http.MethodGet])
 	assert.Equal(1, actualRoutes[http.MethodPatch])
 	assert.Equal(1, actualRoutes[http.MethodDelete])
@@ -671,5 +671,13 @@ func (m *mockUserService) Update(ctx context.Context, id uuid.UUID, user communi
 func (m *mockUserService) Delete(ctx context.Context, id uuid.UUID) error {
 	m.deleteCalled++
 	m.inId = id
+	return m.err
+}
+
+func (m *mockUserService) Login(ctx context.Context, id uuid.UUID) (communication.ApiKeyDtoResponse, error) {
+	return communication.ApiKeyDtoResponse{}, m.err
+}
+
+func (m *mockUserService) Logout(ctx context.Context, id uuid.UUID) error {
 	return m.err
 }

--- a/internal/users/service/user_service.go
+++ b/internal/users/service/user_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/KnoblauchPilze/user-service/pkg/communication"
 	"github.com/KnoblauchPilze/user-service/pkg/db"
+	"github.com/KnoblauchPilze/user-service/pkg/errors"
 	"github.com/KnoblauchPilze/user-service/pkg/repositories"
 	"github.com/google/uuid"
 )
@@ -16,6 +17,8 @@ type UserService interface {
 	List(ctx context.Context) ([]uuid.UUID, error)
 	Update(ctx context.Context, id uuid.UUID, user communication.UserDtoRequest) (communication.UserDtoResponse, error)
 	Delete(ctx context.Context, id uuid.UUID) error
+	Login(ctx context.Context, id uuid.UUID) (communication.ApiKeyDtoResponse, error)
+	Logout(ctx context.Context, id uuid.UUID) error
 }
 
 type userServiceImpl struct {
@@ -102,4 +105,12 @@ func (s *userServiceImpl) Delete(ctx context.Context, id uuid.UUID) error {
 	}
 
 	return nil
+}
+
+func (s *userServiceImpl) Login(ctx context.Context, id uuid.UUID) (communication.ApiKeyDtoResponse, error) {
+	return communication.ApiKeyDtoResponse{}, errors.NewCode(errors.NotImplementedCode)
+}
+
+func (s *userServiceImpl) Logout(ctx context.Context, id uuid.UUID) error {
+	return errors.NewCode(errors.NotImplementedCode)
 }

--- a/pkg/communication/api_key_dto.go
+++ b/pkg/communication/api_key_dto.go
@@ -1,0 +1,12 @@
+package communication
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ApiKeyDtoResponse struct {
+	Key        uuid.UUID
+	ValidUntil time.Time
+}

--- a/pkg/communication/api_key_dto.go
+++ b/pkg/communication/api_key_dto.go
@@ -3,10 +3,18 @@ package communication
 import (
 	"time"
 
+	"github.com/KnoblauchPilze/user-service/pkg/persistence"
 	"github.com/google/uuid"
 )
 
 type ApiKeyDtoResponse struct {
 	Key        uuid.UUID
 	ValidUntil time.Time
+}
+
+func ToApiKeyDtoResponse(apiKey persistence.ApiKey) ApiKeyDtoResponse {
+	return ApiKeyDtoResponse{
+		Key:        apiKey.Key,
+		ValidUntil: apiKey.ValidUntil,
+	}
 }

--- a/pkg/communication/api_key_dto_test.go
+++ b/pkg/communication/api_key_dto_test.go
@@ -1,0 +1,29 @@
+package communication
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KnoblauchPilze/user-service/pkg/persistence"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultKey = uuid.MustParse("872e9e40-ce61-497e-b606-c7a08a4faa14")
+var defaultUser = uuid.MustParse("c74a22da-8a05-43a9-a8b9-717e422b0af4")
+
+func TestToApiKeyDtoResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	k := persistence.ApiKey{
+		Id:         defaultUuid,
+		Key:        defaultKey,
+		ApiUser:    defaultUser,
+		ValidUntil: someTime.Add(2 * time.Hour),
+	}
+
+	actual := ToApiKeyDtoResponse(k)
+
+	assert.Equal(defaultKey, actual.Key)
+	assert.Equal(k.ValidUntil, actual.ValidUntil)
+}

--- a/pkg/communication/user_dto_test.go
+++ b/pkg/communication/user_dto_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var defaultUuid = uuid.MustParse("08ce96a3-3430-48a8-a3b2-b1c987a207ca")
-var someTime = time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+var someTime = time.Date(2024, 05, 05, 20, 50, 18, 651387237, time.UTC)
 
 func TestToUserDtoResponse(t *testing.T) {
 	assert := assert.New(t)

--- a/pkg/rest/echo_interface.go
+++ b/pkg/rest/echo_interface.go
@@ -15,7 +15,7 @@ type echoRouter interface {
 }
 
 type echoServer interface {
-	echoRouter
+	Use(...echo.MiddlewareFunc)
 
 	Group(string, ...echo.MiddlewareFunc) echoRouter
 

--- a/pkg/rest/echo_server_wrapper.go
+++ b/pkg/rest/echo_server_wrapper.go
@@ -6,22 +6,6 @@ type echoServerImpl struct {
 	e *echo.Echo
 }
 
-func (esi *echoServerImpl) GET(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route {
-	return esi.e.GET(path, h, m...)
-}
-
-func (esi *echoServerImpl) POST(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route {
-	return esi.e.POST(path, h, m...)
-}
-
-func (esi *echoServerImpl) DELETE(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route {
-	return esi.e.DELETE(path, h, m...)
-}
-
-func (esi *echoServerImpl) PATCH(path string, h echo.HandlerFunc, m ...echo.MiddlewareFunc) *echo.Route {
-	return esi.e.PATCH(path, h, m...)
-}
-
 func (esi *echoServerImpl) Use(m ...echo.MiddlewareFunc) {
 	esi.e.Use(m...)
 }


### PR DESCRIPTION
# Work

## The problem and the research

We want to provide endpoints to allow a specific user to login and logout of the service. The idea is to repurpose the API keys we currently have in the service to something more similar to a session key. It would go along the lines of what is described in [this article from kong](https://konghq.com/blog/learning-center/what-are-api-keys).

A simple way to do this would be to provide two new endpoints, `users/:id/login` and `users/:id/logout` to handle the authentication. However after looking it up on the Internet it seems like in general this is not very RESTful. Here's a sample of articles we found:
* SO article on [designing login or register resources](https://stackoverflow.com/questions/7140074/restfully-design-login-or-register-resources).
*SO article on [sessions](https://stackoverflow.com/questions/6068113/do-sessions-really-violate-restfulness) and whether they iolate RESTfulness.

The second article seems to be a bit more pragmatic and indicates that while sessions might violate pure RESTfulness, it seems too useful to not use it. When looking at what tutanota is doing we see they use a similar concept:

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/544cbad7-a25f-404f-97af-30b8bced50e9)

There's a call to a `sessionservice` which is used to authenticate the current user and returns an access token:

![image](https://github.com/Knoblauchpilze/user-service/assets/33599677/7ef73478-c789-4004-b46e-144c45ac3142)

It seems very similar to the concept of API key we have.

## The implementation

Contrary to our initial design, this PR brings a new session controller which is used to handle authentication for logging in and out. The endpoints are as follows:
```
POST /users/sessions/{user-id}
DELETE /users/sessions/{user-id}
```

* when logging in, a new API key will be generated if the user exists and is not already logged in. If it is already logged in we will just refresh the existing token to enforce idempotency.
* on logout the API key will be deleted from the service.

To implement these new endpoints we reintroduced some of the code that was removed in [dd05626](https://github.com/Knoblauchpilze/user-service/commit/dd056263bf1e5dc6a186212d79312beb4b972922): the generation of the API key follows the same algorithm whether it is done when creating the user or when logging in.

# Tests
* Updated the `ApiKeyRepository` tests to adapt to the new interface (versions without transactions).
* Added tests for the `UserService` to cover the new `Login` and `Logout` methods.
* The http handlers for login and logout are also covered by tests.

The conversion between the DB entity and the response DTO was also covered by a simple test case.

# Future work

It turns out the login/logout is at least as much about authentication as about REST API design. While researching, we found quite a few resources indicating various ways to perform authentication.

What seemed like a useful resource for the future is this REST cook book [article](https://restcookbook.com/Basics/loggingin/) which shows various ways to authenticate requests made to an API.

We could most likely revisit this mechanism later on.
