### PR TITLE
feat: Only deploy services once

### DIFF
--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -31,8 +31,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   build-user-service:
     needs: [tests]
-    permissions:
-      contents: write
     uses: ./.github/workflows/user-service-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,3 +43,16 @@ jobs:
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ needs.build-user-service.outputs.service-tag }}"
+  persist-service-tag:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: [build-user-service, build-stellar-dominion-service]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/services-persist-tag.yml
+    with:
+      service-name: stellar-dominion-service
+      service-tag: ${{ needs.build-user-service.outputs.service-tag }}

--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -45,6 +45,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   debug:
     runs-on: ubuntu-latest
+    needs: [build-user-service, build-stellar-dominion-service]
     steps:
       - run: echo "${{ needs.build-user-service.outputs.service-tag }}"
   persist-service-tag:

--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -43,12 +43,6 @@ jobs:
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-  debug:
-    runs-on: ubuntu-latest
-    needs: [build-user-service, build-stellar-dominion-service]
-    steps:
-      - run: echo "${{ needs.build-user-service.outputs.service-tag }}"
-      - run: echo "${{ needs.build-stellar-dominion-service.outputs.service-tag }}"
   persist-service-tags:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -48,12 +48,24 @@ jobs:
     needs: [build-user-service, build-stellar-dominion-service]
     steps:
       - run: echo "${{ needs.build-user-service.outputs.service-tag }}"
-  persist-service-tag:
+      - run: echo "${{ needs.build-stellar-dominion-service.outputs.service-tag }}"
+  persist-service-tags:
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-user-service, build-stellar-dominion-service]
+    # https://stackoverflow.com/questions/72851548/permission-denied-to-github-actionsbot
     permissions:
       contents: write
-    uses: ./.github/workflows/services-persist-tag.yml
-    with:
-      service-name: stellar-dominion-service
-      service-tag: ${{ needs.build-user-service.outputs.service-tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Save user-service tag
+        run: echo "${{ needs.build-user-service.outputs.service-tag }}" > ./build/user-service/version.txt
+      - name: Save stellar-dominion-service tag
+        run: echo "${{ needs.build-stellar-dominion-service.outputs.service-tag }}" > ./build/stellar-dominion-service/version.txt
+      - name: Commit changes
+        run: |
+          git pull
+          git config --global user.name 'totocorpbot'
+          git config --global user.email 'totocorpbot@users.noreply.github.com'
+          git commit -am "infra: Bumped services versions to latest revision"
+          git push

--- a/.github/workflows/services-persist-tag.yml
+++ b/.github/workflows/services-persist-tag.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   persist-service-tag:
     runs-on: ubuntu-latest
-    # https://stackoverflow.com/questions/72851548/permission-denied-to-github-actionsbot
     permissions:
       contents: write
     steps:

--- a/.github/workflows/stellar-dominion-service-build-and-push.yml
+++ b/.github/workflows/stellar-dominion-service-build-and-push.yml
@@ -7,6 +7,10 @@ on:
         required: true
       dockerhub-token:
         required: true
+    outputs:
+      service-tag:
+        description: "Tag of the generated service docker image"
+        value: ${{ jobs.extract-service-tag.outputs.version }}
   push:
     paths:
       - "build/stellar-dominion-service/Dockerfile"
@@ -32,12 +36,3 @@ jobs:
           build-args: GIT_COMMIT_HASH=${{ needs.extract-service-tag.outputs.version }}
           push: true
           tags: totocorpsoftwareinc/stellar-dominion-service:${{ needs.extract-service-tag.outputs.version }}
-  persist-service-tag:
-    if: ${{ github.ref == 'refs/heads/master' }}
-    needs: [build-and-push-docker-image, extract-service-tag]
-    permissions:
-      contents: write
-    uses: ./.github/workflows/services-persist-tag.yml
-    with:
-      service-name: stellar-dominion-service
-      service-tag: ${{ needs.extract-service-tag.outputs.version }}

--- a/.github/workflows/user-service-build-and-push.yml
+++ b/.github/workflows/user-service-build-and-push.yml
@@ -7,6 +7,11 @@ on:
         required: true
       dockerhub-token:
         required: true
+    # https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow
+    outputs:
+      service-tag:
+        description: "Tag of the generated service docker image"
+        value: ${{ jobs.extract-service-tag.outputs.version }}
   push:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths
     paths:
@@ -35,15 +40,3 @@ jobs:
           build-args: GIT_COMMIT_HASH=${{ needs.extract-service-tag.outputs.version }}
           push: true
           tags: totocorpsoftwareinc/user-service:${{ needs.extract-service-tag.outputs.version }}
-  persist-service-tag:
-    # https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions
-    if: ${{ github.ref == 'refs/heads/master' }}
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
-    needs: [build-and-push-docker-image, extract-service-tag]
-    # https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-and-permissions
-    permissions:
-      contents: write
-    uses: ./.github/workflows/services-persist-tag.yml
-    with:
-      service-name: user-service
-      service-tag: ${{ needs.extract-service-tag.outputs.version }}


### PR DESCRIPTION
# Work

Currently each service that we build is committing the new tag of the docker image. This in turns triggers the [deploy-services](https://github.com/Knoblauchpilze/user-service/blob/master/.github/workflows/deploy-services.yml) workflow to deploy the new code.

This is a bit problematic because potentially we can run into concurrency between the services trying to update the remote host. In #11 we improved the situation to make sure that the deploy workflow is able to handle additional commits (from other services for example). In [1716831](https://github.com/Knoblauchpilze/user-service/commit/17168312335a92d82afa3160405ad3dedd003a3f) we added a concurrency option which cancels any running workflow when needed: this prevents multiple deploy commands to be issued simultaneously.

But those changes do not address the problem at its root: we do have two separate workflows running and issuing the deploy command.

In this PR, we want to fix this by changing who's persisting the versions: we want the new `build-services` workflow we introduced in #13 (it was renamed in [d27d683](https://github.com/Knoblauchpilze/user-service/commit/d27d683ddbefa0aa05eb916dfe8f1bb2a0300036) to take care of it. It will group the updates to both the `user-service` and the `stellar-dominion-service` in a single command.

We found some good documentation in the github reference about using outputs from a reusable workflow [here](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow). This is what we used to achieve the desired result in the PR.

# Tests

We made sure that we can [read the output](https://github.com/Knoblauchpilze/user-service/actions/runs/10442459763/job/28914793831?pr=15) from the reusable workflows in the main `build-services` workflow:

![image](https://github.com/user-attachments/assets/ee76c1b6-03d7-4d34-b990-112f17cf183a)

Additionally, we verified that the commit would happen only after both services were successfully built:

![image](https://github.com/user-attachments/assets/47801a6b-955e-45ee-803a-20f2bc92290a)

(it is skipped in this image because we're on a feature branch)

# Future work

As mentioned in #14 we could see to also include the frontend in the `build-services` workflow to have a single unique CI workflow.
