### PR TITLE
feat: Only build frontend services when the code changes

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -32,24 +32,27 @@ jobs:
               - 'website/stellar-dominion/**'
   build-user-dashboard:
     needs: [analyze-changes]
-    steps:
-      - uses: ./.github/workflows/user-dashboard-build-and-push.yml
-        if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
-        secrets:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+    if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
+    uses: ./.github/workflows/user-dashboard-build-and-push.yml
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
     needs: [analyze-changes]
-    steps:
-      - uses: ./.github/workflows/stellar-dominion-build-and-push.yml
-        if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
-        secrets:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+    if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
+    uses: ./.github/workflows/stellar-dominion-build-and-push.yml
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    # if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-user-dashboard, build-stellar-dominion]
+    # https://github.com/actions/runner/issues/491
+    if: |
+      always() &&
+      ${{ github.ref == 'refs/heads/master' }} &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.ref_name }}
           # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
           filters: |
             user-dashboard:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -51,7 +51,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'cancelled')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -13,12 +13,25 @@ on:
       - "!.github/workflows/stellar-dominion-service*.yml"
 
 jobs:
+  # https://github.com/dorny/paths-filter
+  analyze-changes:
+    uses: dorny/paths-filter@v3
+    id: changes
+    with:
+      # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
+      filters: |
+        user-dashboard:
+          - 'website/user-dashboard/**'
+        stellar-dominion:
+          - 'website/stellar-dominion/**'
   build-user-dashboard:
+    if: steps.analyze-changes.outputs.user-dashboard == 'true'
     uses: ./.github/workflows/user-dashboard-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
+    if: steps.analyze-changes.outputs.stellar-dominion == 'true'
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -43,7 +43,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    # if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-user-dashboard, build-stellar-dominion]
     permissions:
       contents: write

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   # https://github.com/dorny/paths-filter
-  analyze-changes:
+  detect-code-changes:
     runs-on: ubuntu-latest
     outputs:
       user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
@@ -31,23 +31,38 @@ jobs:
               - 'website/user-dashboard/**'
             stellar-dominion:
               - 'website/stellar-dominion/**'
+            ci:
+              - '.github/workflows/**'
+  analyze-code-changes:
+    runs-on: ubuntu-latest
+    needs: [detect-code-changes]
+    outputs:
+      user-dashboard: ${{ steps.user-dashboard.outputs.rebuild }}
+      stellar-dominion: ${{ steps.stellar-dominion.outputs.rebuild }}
+    steps:
+      - name: user-dashboard rebuild status
+        id: user-dashboard
+        run: echo 'rebuild=${{ needs.detect-code.outputs.user-dashboard == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+      - name: stellar-dominion rebuild status
+        id: stellar-dominion
+        run: echo 'rebuild=${{ needs.detect-code.outputs.stellar-dominion == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
   build-user-dashboard:
-    needs: [analyze-changes]
-    if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
+    needs: [detect-code-changes]
+    if: ${{ needs.detect-code-changes.outputs.user-dashboard == 'true' }}
     uses: ./.github/workflows/user-dashboard-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
-    needs: [analyze-changes]
-    if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
+    needs: [detect-code-changes]
+    if: ${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' }}
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    needs: [analyze-changes, build-user-dashboard, build-stellar-dominion]
+    needs: [detect-code-changes, build-user-dashboard, build-stellar-dominion]
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&
@@ -58,13 +73,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Save user-dashboard tag
-        if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
+        if: ${{ needs.detect-code-changes.outputs.user-dashboard == 'true' }}
         run: echo "${{ needs.build-user-dashboard.outputs.service-tag }}" > ./build/user-dashboard/version.txt
       - name: Save stellar-dominion tag
-        if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
+        if: ${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
-        if: ${{ needs.analyze-changes.outputs.* == 'true' }}
+        if: ${{ needs.detect-code-changes.outputs.* == 'true' }}
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   # https://github.com/dorny/paths-filter
   analyze-changes:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -27,6 +27,14 @@ jobs:
               - 'website/user-dashboard/**'
             stellar-dominion:
               - 'website/stellar-dominion/**'
+  debug:
+    runs-on: ubuntu-latest
+    needs: [analyze-changes]
+    steps:
+      - name: debug
+      - run: |
+        echo "$ {{ needs.analyze-changes.outputs.user-dashboard }}"
+        echo "$ {{ needs.analyze-changes.outputs.stellar-dominion }}"
   build-user-dashboard:
     needs: [analyze-changes]
     if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -46,7 +46,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    needs: [build-user-dashboard, build-stellar-dominion]
+    needs: [analyze-changes, build-user-dashboard, build-stellar-dominion]
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,15 +15,17 @@ on:
 jobs:
   # https://github.com/dorny/paths-filter
   analyze-changes:
-    uses: dorny/paths-filter@v3
-    id: changes
-    with:
-      # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
-      filters: |
-        user-dashboard:
-          - 'website/user-dashboard/**'
-        stellar-dominion:
-          - 'website/stellar-dominion/**'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
+          filters: |
+            user-dashboard:
+              - 'website/user-dashboard/**'
+            stellar-dominion:
+              - 'website/stellar-dominion/**'
   build-user-dashboard:
     if: steps.analyze-changes.outputs.user-dashboard == 'true'
     uses: ./.github/workflows/user-dashboard-build-and-push.yml

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -71,7 +71,6 @@ jobs:
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&
-      ${{ github.ref == 'refs/heads/master' }} &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     permissions:
@@ -85,7 +84,7 @@ jobs:
         if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
-        if: ${{ needs.analyze-code-changes.outputs.persist-tags == 'true' }}
+        if: ${{ github.ref == 'refs/heads/master' && needs.analyze-code-changes.outputs.persist-tags == 'true' }}
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -63,7 +63,7 @@ jobs:
     if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-username: hello
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       user-dashboard: ${{ steps.user-dashboard.outputs.rebuild }}
       stellar-dominion: ${{ steps.stellar-dominion.outputs.rebuild }}
+      persist-tags: ${{ steps.persist-tags.outputs.status }}
     steps:
       - name: user-dashboard rebuild status
         id: user-dashboard
@@ -47,6 +48,9 @@ jobs:
       - name: stellar-dominion rebuild status
         id: stellar-dominion
         run: echo 'rebuild=${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+      - name: stellar-dominion rebuild status
+        id: persist-tags
+        run: echo 'status=${{ needs.detect-code-changes.outputs.user-dashboard == 'true' || needs.detect-code-changes.outputs.stellar-dominion == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
   build-user-dashboard:
     needs: [analyze-code-changes]
     if: ${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }}
@@ -80,7 +84,7 @@ jobs:
         if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
-        if: ${{ needs.analyze-code-changes.outputs.* == 'true' }}
+        if: ${{ needs.analyze-code-changes.outputs.persist-tags == 'true' }}
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -63,7 +63,7 @@ jobs:
     if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
-      dockerhub-username: hello
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -21,8 +21,8 @@ jobs:
       stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
     steps:
       - name: Analyze code changes
-      - uses: dorny/paths-filter@v3
         id: filter
+      - uses: dorny/paths-filter@v3
         with:
           # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
           filters: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -35,34 +35,34 @@ jobs:
               - '.github/workflows/**'
   analyze-code-changes:
     runs-on: ubuntu-latest
-    needs: [detect-code-changes]
+    needs: [analyze-code-changes]
     outputs:
       user-dashboard: ${{ steps.user-dashboard.outputs.rebuild }}
       stellar-dominion: ${{ steps.stellar-dominion.outputs.rebuild }}
     steps:
       - name: user-dashboard rebuild status
         id: user-dashboard
-        run: echo 'rebuild=${{ needs.detect-code.outputs.user-dashboard == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
       - name: stellar-dominion rebuild status
         id: stellar-dominion
-        run: echo 'rebuild=${{ needs.detect-code.outputs.stellar-dominion == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
   build-user-dashboard:
-    needs: [detect-code-changes]
-    if: ${{ needs.detect-code-changes.outputs.user-dashboard == 'true' }}
+    needs: [analyze-code-changes]
+    if: ${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }}
     uses: ./.github/workflows/user-dashboard-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
-    needs: [detect-code-changes]
-    if: ${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' }}
+    needs: [analyze-code-changes]
+    if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    needs: [detect-code-changes, build-user-dashboard, build-stellar-dominion]
+    needs: [analyze-code-changes, build-user-dashboard, build-stellar-dominion]
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&
@@ -73,13 +73,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Save user-dashboard tag
-        if: ${{ needs.detect-code-changes.outputs.user-dashboard == 'true' }}
+        if: ${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }}
         run: echo "${{ needs.build-user-dashboard.outputs.service-tag }}" > ./build/user-dashboard/version.txt
       - name: Save stellar-dominion tag
-        if: ${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' }}
+        if: ${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
-        if: ${{ needs.detect-code-changes.outputs.* == 'true' }}
+        if: ${{ needs.analyze-code-changes.outputs.* == 'true' }}
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -35,7 +35,7 @@ jobs:
               - '.github/workflows/**'
   analyze-code-changes:
     runs-on: ubuntu-latest
-    needs: [analyze-code-changes]
+    needs: [detect-code-changes]
     outputs:
       user-dashboard: ${{ steps.user-dashboard.outputs.rebuild }}
       stellar-dominion: ${{ steps.stellar-dominion.outputs.rebuild }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -71,6 +71,7 @@ jobs:
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&
+      ${{ github.ref == 'refs/heads/master' }} &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     permissions:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,10 +16,13 @@ jobs:
   # https://github.com/dorny/paths-filter
   analyze-changes:
     runs-on: ubuntu-latest
+    outputs:
+      user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
+      stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
     steps:
-      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
-        id: changes
+      - name: Analyze code changes
+        id: filter
         with:
           # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
           filters: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -28,13 +28,15 @@ jobs:
             stellar-dominion:
               - 'website/stellar-dominion/**'
   build-user-dashboard:
-    if: steps.analyze-changes.outputs.user-dashboard == 'true'
+    needs: [analyze-changes]
+    if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
     uses: ./.github/workflows/user-dashboard-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
-    if: steps.analyze-changes.outputs.stellar-dominion == 'true'
+    needs: [analyze-changes]
+    if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
     uses: ./.github/workflows/stellar-dominion-build-and-push.yml
     secrets:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,8 +20,8 @@ jobs:
       user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
       stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
     steps:
-      - uses: dorny/paths-filter@v3
       - name: Analyze code changes
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -32,9 +32,9 @@ jobs:
     needs: [analyze-changes]
     steps:
       - name: debug
-      - run: |
-        echo "$ {{ needs.analyze-changes.outputs.user-dashboard }}"
-        echo "$ {{ needs.analyze-changes.outputs.stellar-dominion }}"
+        run: |
+          echo "$ {{ needs.analyze-changes.outputs.user-dashboard }}"
+          echo "$ {{ needs.analyze-changes.outputs.stellar-dominion }}"
   build-user-dashboard:
     needs: [analyze-changes]
     if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -30,14 +30,6 @@ jobs:
               - 'website/user-dashboard/**'
             stellar-dominion:
               - 'website/stellar-dominion/**'
-  debug:
-    runs-on: ubuntu-latest
-    needs: [analyze-changes]
-    steps:
-      - name: debug
-        run: |
-          echo "$ {{ needs.analyze-changes.outputs.user-dashboard }}"
-          echo "$ {{ needs.analyze-changes.outputs.stellar-dominion }}"
   build-user-dashboard:
     needs: [analyze-changes]
     if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
@@ -54,7 +46,7 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-user-dashboard, build-stellar-dominion]
     permissions:
       contents: write

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,9 +20,8 @@ jobs:
       user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
       stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
     steps:
-      - name: Analyze code changes
-        id: filter
       - uses: dorny/paths-filter@v3
+        id: filter
         with:
           # https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
           filters: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -50,7 +50,6 @@ jobs:
     # https://github.com/actions/runner/issues/491
     if: |
       always() &&
-      ${{ github.ref == 'refs/heads/master' }} &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     permissions:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -32,18 +32,20 @@ jobs:
               - 'website/stellar-dominion/**'
   build-user-dashboard:
     needs: [analyze-changes]
-    if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
-    uses: ./.github/workflows/user-dashboard-build-and-push.yml
-    secrets:
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: ./.github/workflows/user-dashboard-build-and-push.yml
+        if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
+        secrets:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   build-stellar-dominion:
     needs: [analyze-changes]
-    if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
-    uses: ./.github/workflows/stellar-dominion-build-and-push.yml
-    secrets:
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: ./.github/workflows/stellar-dominion-build-and-push.yml
+        if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
+        secrets:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
     # if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -51,7 +51,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
     permissions:
       contents: write
     steps:
@@ -63,6 +63,7 @@ jobs:
         if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
+        if: ${{ needs.analyze-changes.outputs.* == 'true' }}
         run: |
           git pull
           git config --global user.name 'totocorpbot'

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -43,15 +43,17 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
   persist-service-tags:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # if: ${{ github.ref == 'refs/heads/master' }}
     needs: [build-user-dashboard, build-stellar-dominion]
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Save user-dashboard tag
+        if: ${{ needs.analyze-changes.outputs.user-dashboard == 'true' }}
         run: echo "${{ needs.build-user-dashboard.outputs.service-tag }}" > ./build/user-dashboard/version.txt
       - name: Save stellar-dominion tag
+        if: ${{ needs.analyze-changes.outputs.stellar-dominion == 'true' }}
         run: echo "${{ needs.build-stellar-dominion.outputs.service-tag }}" > ./build/stellar-dominion/version.txt
       - name: Commit changes
         run: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - name: user-dashboard rebuild status
         id: user-dashboard
-        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
       - name: stellar-dominion rebuild status
         id: stellar-dominion
-        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' }} || ${{ needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
   build-user-dashboard:
     needs: [analyze-code-changes]
     if: ${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - name: user-dashboard rebuild status
         id: user-dashboard
-        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.detect-code-changes.outputs.user-dashboard == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
       - name: stellar-dominion rebuild status
         id: stellar-dominion
-        run: echo 'rebuild=${{ needs.analyze-code-changes.outputs.stellar-dominion == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
+        run: echo 'rebuild=${{ needs.detect-code-changes.outputs.stellar-dominion == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}' >> $GITHUB_OUTPUT
   build-user-dashboard:
     needs: [analyze-code-changes]
     if: ${{ needs.analyze-code-changes.outputs.user-dashboard == 'true' }}

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -20,6 +20,7 @@ jobs:
       user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
       stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       user-dashboard: ${{ steps.filter.outputs.user-dashboard }}
       stellar-dominion: ${{ steps.filter.outputs.stellar-dominion }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/stellar-dominion-build-and-push.yml
+++ b/.github/workflows/stellar-dominion-build-and-push.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           username: ${{ secrets.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
-      - name: Build and push
+      - name: Build and pushs
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/stellar-dominion-build-and-push.yml
+++ b/.github/workflows/stellar-dominion-build-and-push.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           username: ${{ secrets.dockerhub-username }}
           password: ${{ secrets.dockerhub-token }}
-      - name: Build and pushs
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
+++ b/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
@@ -46,7 +46,7 @@
 		</div>
 
 		<CenteredWrapper>
-			<StyledTitle text="Buildings ond {planetName}" />
+			<StyledTitle text="Buildings on {planetName}" />
 			<!-- https://tailwindcss.com/docs/align-items -->
 			<div class="w-full h-full flex flex-wrap items-start bg-transparent">
 				{#each buildings as building}

--- a/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
+++ b/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
@@ -18,7 +18,7 @@
 	// https://stackoverflow.com/questions/75616911/sveltekit-fetching-on-the-server-and-updating-the-writable-store
 	heroImage.set(GAME_HERO_IMAGE);
 	heroContainer.set(GAME_HERO_CONTAINER_PROPS);
-	const title = HOMEPAGE_TITLE + " - " + data.planet.name;
+	const title = HOMEPAGE_TITLE + ' - ' + data.planet.name;
 	pageTitle.set(title);
 
 	const resources = mapPlanetResourcesToUiResources(data.planet.resources, data.resources);
@@ -46,7 +46,7 @@
 		</div>
 
 		<CenteredWrapper>
-			<StyledTitle text="Buildings on {planetName}" />
+			<StyledTitle text="Buildings ond {planetName}" />
 			<!-- https://tailwindcss.com/docs/align-items -->
 			<div class="w-full h-full flex flex-wrap items-start bg-transparent">
 				{#each buildings as building}

--- a/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
+++ b/website/stellar-dominion/src/routes/planets/[planet=id]/overview/+page.svelte
@@ -46,7 +46,7 @@
 		</div>
 
 		<CenteredWrapper>
-			<StyledTitle text="Buildings on {planetName}" />
+			<StyledTitle text="Buildings ond {planetName}" />
 			<!-- https://tailwindcss.com/docs/align-items -->
 			<div class="w-full h-full flex flex-wrap items-start bg-transparent">
 				{#each buildings as building}


### PR DESCRIPTION
# Work

The frontend workflow builds both the `user-dashboard` and the `stellar-dominion` no matter whether only one of them was changed. This is not optimal. After looking online, this [stack overflow](https://stackoverflow.com/questions/70809269/in-github-actions-in-an-expression-is-there-a-way-to-determine-what-path-direct) seems to indicate that we can't detect through github framework alone whether a path was changed when triggering a workflow.

This [dorny action](https://github.com/dorny/paths-filter?tab=readme-ov-file) seems to be able to do this however. After fiddling a bit we were able to implement a condition that only triggers the build of the frontend service in case some code path was changed for it.

After trying out to make the jobs skippable based on the code changes, we noticed that the fact that the persist step is registered as `needs: [build-user-dashboard, build-stellar-dominion]` indicates that it can't run **unless both services** are modified. This is of course not what we want. It also seems to be a feature and not a bug (see the discussion in [this](https://github.com/actions/runner/issues/491) issue). This [comment](https://github.com/actions/runner/issues/491#issuecomment-907216595) seems to provide a workaround (or a correct syntax rather).

Additionally, just detecting whether the code of one of the service changed is not enough: in case the CI workflows are updated, we want to 'override' the logic and trigger a rebuild of both services. This was brought mainly in [432614c](https://github.com/Knoblauchpilze/user-service/pull/17/commits/432614c5bbb71f906a3a242f0af913a0e5ebd712) (and fixed in later commits).

# Tests

This [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/10443601871) on this branch shows how it looks like when only one of the services needs to be rebuilt:
* we correctly trigger the build only for the `stellar-dominion` project.
* the persistence of the tags is still triggered.

![image](https://github.com/user-attachments/assets/8ca1ffda-885b-466e-aea3-da5fed566d25)

Additionally, only the `stellar-dominion` sees its version bumped (see the related CI commit [ae41420](https://github.com/Knoblauchpilze/user-service/pull/17/commits/ae4142095ce8900719616083e6fe480b926cc67a)).

We correctly detect that only the `stellar-dominion` service needs to be rebuilt and so we don't trigger the change in the `user-dashboard`. Also when the CI workflows are changed with no other code changed, it still triggers the rebuild of both services.

For example [927ebf1](https://github.com/Knoblauchpilze/user-service/pull/17/commits/927ebf1b91e3d3e59ba7fc3fa118226ad0f7fa2e) generated [this workflow run](https://github.com/Knoblauchpilze/user-service/actions/runs/10456659122):

![image](https://github.com/user-attachments/assets/d3c0f95b-942a-4cd6-9e02-8833dc88b400)

Finally in case one of the steps within the workflow fails, we correctly skip the `persist tags` step:

![image](https://github.com/user-attachments/assets/658e417a-feb8-457b-be1d-4908ece4e73e)

# Future work

N/A.
