### PR TITLE
feat: Verification of the CI checks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -225,7 +225,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - uses: actions/checkout@v4
       - name: Substitute acme email
@@ -289,7 +289,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - name: Deploy latest services version
         uses: appleboy/ssh-action@v1.0.3
@@ -305,7 +305,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - name: Clean back-up of deployment config
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Detect if service tags should be persisted
         id: persist-tags
         run: |
-          echo 'persist=${{ needs.analyze-code-changes.outputs.user-service == 'true' || needs.analyze-code-changes.outputs.stellar-dominion-service == 'true' || needs.analyze-code-changes.outputs.user-dashboard == 'true' || needs.analyze-code-changes.outputs.stellar-dominion == 'true' }}' >> $GITHUB_OUTPUT
+          echo 'persist=${{ (github.ref == 'refs/heads/master') && (needs.analyze-code-changes.outputs.user-service == 'true' || needs.analyze-code-changes.outputs.stellar-dominion-service == 'true' || needs.analyze-code-changes.outputs.user-dashboard == 'true' || needs.analyze-code-changes.outputs.stellar-dominion == 'true') }}' >> $GITHUB_OUTPUT
   analyze-deploy-status:
     runs-on: ubuntu-latest
     needs: [detect-code-changes, analyze-persist-tags-status]
@@ -158,30 +158,6 @@ jobs:
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  debug:
-    runs-on: ubuntu-latest
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
-    needs:
-      [
-        analyze-deploy-status,
-        build-user-service,
-        build-stellar-dominion-service,
-        build-user-dashboard,
-        build-stellar-dominion,
-      ]
-    if: |
-      always()
-    steps:
-      - name: Print debug
-        run: |
-          echo "deploy ${{ needs.analyze-deploy-status.result }}"
-          echo "us ${{ needs.build-user-service.result }}"
-          echo "sds ${{ needs.build-stellar-dominion-service.result }}"
-          echo "ud ${{ needs.build-user-dashboard.result }}"
-          echo "sd ${{ needs.build-stellar-dominion.result }}"
-          echo "failure: ${{ !contains(needs.*.result, 'failure') }}"
-          echo "cancelled: ${{ !contains(needs.*.result, 'cancelled') }}"
-
   backup-deployment-config:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
@@ -217,6 +193,7 @@ jobs:
       [
         backup-deployment-config,
         analyze-code-changes,
+        analyze-deploy-status,
         build-user-service,
         build-stellar-dominion-service,
         build-user-dashboard,
@@ -225,7 +202,8 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
+      needs.analyze-deploy-status.outputs.deploy-services == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Substitute acme email
@@ -285,11 +263,12 @@ jobs:
           rsync -avzh ./deployments ubuntu@${{ secrets.EC2_DEPLOY_HOST }}:/home/ubuntu//
   deploy:
     runs-on: ubuntu-latest
-    needs: [sync-deployment-configuration]
+    needs: [analyze-deploy-status, sync-deployment-configuration]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
+      needs.analyze-deploy-status.outputs.deploy-services == 'true'
     steps:
       - name: Deploy latest services version
         uses: appleboy/ssh-action@v1.0.3
@@ -301,11 +280,12 @@ jobs:
             docker compose -f ./deployments/compose.yaml up -d
   clean-deployment-config-backup:
     runs-on: ubuntu-latest
-    needs: [deploy]
+    needs: [analyze-deploy-status, deploy]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
+      needs.analyze-deploy-status.outputs.deploy-services == 'true'
     steps:
       - name: Clean back-up of deployment config
         uses: appleboy/ssh-action@v1.0.3
@@ -333,7 +313,7 @@ jobs:
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      github.ref == 'refs/heads/master' && 
+      github.ref == 'refs/heads/master' &&
       needs.analyze-persist-tags-status.outputs.persist == 'true'
     permissions:
       contents: write

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -358,7 +358,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - uses: actions/checkout@v4
       - name: user-service tag

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -358,7 +358,7 @@ jobs:
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+      !contains(needs.*.result, 'cancelled') &&
     steps:
       - uses: actions/checkout@v4
       - name: user-service tag


### PR DESCRIPTION
# Work

Now that we have a unified CI workflow, we want to make sure that when opening a PR we can't merge it if the checks are not passing. We introduced a new `finish` in [9ec7eee](https://github.com/Knoblauchpilze/user-service/commit/9ec7eee1282600977542e4d39e0a1d2a16969688) and [beeb3be](https://github.com/Knoblauchpilze/user-service/commit/beeb3beee0f05c8d2a20efe44166b042e934a280) step in the CI which we will use as a check to allow merging a PR.

# Tests

We broke the build with an invalid commit (see [13966a3](https://github.com/Knoblauchpilze/user-service/pull/18/commits/13966a3f6609772a02313e005ae5c9c43e8f3617)) and after adding a check in the settings of the repository we can see that the merge is disabled for this PR:

![image](https://github.com/user-attachments/assets/771c779c-e356-4258-a2d3-59578e163c17)

Fixing the workflow allows to merge again:

![image](https://github.com/user-attachments/assets/f7811cb4-9f49-42e5-997f-f7860bf37070)

# Future work

N/A.
