### PR TITLE
feat: Added CI workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    allow:
+      - dependency-type: "direct"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+
+# Work
+
+# Tests
+
+# Future work

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,39 @@
+name: Build services
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "database/**"
+      - "pkg/**"
+      - "internal/**"
+      - "cmd/**"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    needs: [analyze-code-changes]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
+      - name:
+        uses: ikalnytskyi/action-setup-postgres@v7
+        with:
+          username: test_user
+          password: test_password
+          database: test_db
+          port: 5432
+          postgres-version: "15"
+          ssl: true
+          id: postgres
+      - name: Run tests with coverage
+        run: go test ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          file: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Work

Added CI workflow. We want to introduce integration tests for the database quite early. This will be done in a similar way to how it's done in [pgx](https://github.com/jackc/pgx/blob/master/.github/workflows/ci.yml#L133C27-L133C48), using [action-setup-progress](https://github.com/ikalnytskyi/action-setup-postgres).

# Tests

Sadly we can't really test this as it's not yet merged to master;

# Future work
