### PR TITLE
feat: Added CI step for db migrations

### DIFF
--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -32,6 +32,9 @@ jobs:
     defaults:
       run:
         working-directory: ./database
+    env:
+      PGPASSWORD: postgres
+      USER_PASSWORD: test_password
     # https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o
     services:
       postgres:
@@ -52,9 +55,6 @@ jobs:
       - name: Create user
         run: |
           psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
-        env:
-          PGPASSWORD: postgres
-          USER_PASSWORD: test_password
       - name: Create database
         run: |
           psql postgresql://postgres@localhost -f test/db_create.sql

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -1,0 +1,47 @@
+name: Build and deploy services
+
+on:
+  push:
+    paths:
+      - ".github/workflows/database-migration-tests.yml"
+      - "database/**"
+
+jobs:
+  # https://github.com/dorny/paths-filter
+  detect-code-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ci: ${{ steps.filter.outputs.ci }}
+      test-db: ${{ steps.filter.outputs.deployment }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ github.ref_name }}
+          filters: |
+            ci:
+              - '.github/workflows/database-migration-tests.yml'
+            test-db:
+              - 'database/test/**'
+  run-test-db-migrations:
+    runs-on: ubuntu-latest
+    needs: [detect-code-changes]
+    if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.analyze-code-changes.outputs.ci == 'true' }}
+    env:
+      USER_PASSWORD: test_password
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
+      - name: Setup postgresql
+        uses: ikalnytskyi/action-setup-postgres@v7
+        id: postgres
+      - name: Install migrate tool
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - name: Create user
+        run: ./database/create_user.sh test
+      - name: Create database
+        run: ./database/create_database.sh test

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -39,11 +39,10 @@ jobs:
       - name: Setup postgresql
         uses: ikalnytskyi/action-setup-postgres@v7
         id: postgres
-      - name: Install migrate tool
-        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Create user
+        # https://github.com/ikalnytskyi/action-setup-postgres?tab=readme-ov-file#recommended
         run: |
-          psql -U postgres postgres -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
+          psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
       - name: Create database
         run: |
           psql -U postgres postgres -f ./database/test/db_create.sql

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -32,9 +32,6 @@ jobs:
     defaults:
       run:
         working-directory: ./database
-    env:
-      PGPASSWORD: postgres
-      USER_PASSWORD: test_password
     # https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o
     services:
       postgres:
@@ -61,12 +58,21 @@ jobs:
       - name: Create user
         run: |
           psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
+        env:
+          PGPASSWORD: postgres
+          USER_PASSWORD: test_password
       - name: Create database
         run: |
           psql postgresql://postgres@localhost -f test/db_create.sql
+        env:
+          PGPASSWORD: postgres
       - name: Migrate schema up
         run: |
           migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable up
+        env:
+          PGPASSWORD: test_password
       - name: Migrate schema down
         run: |
           migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable down -all
+        env:
+          PGPASSWORD: test_password

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -52,17 +52,17 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Install migrate tool
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Create user
         run: |
           psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
       - name: Create database
         run: |
           psql postgresql://postgres@localhost -f test/db_create.sql
-      # - name: Install migrate tool
-      #   run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
-      # - name: Migrate schema up
-      #   run: |
-      #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
-      # - name: Migrate schema down
-      #   run: |
-      #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all
+      - name: Migrate schema up
+        run: |
+          migrate -path test/migrations -database postgresql://test_user@localhost/test_db up
+      - name: Migrate schema down
+        run: |
+          migrate -path test/migrations -database postgresql://test_user@localhost/test_db down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -52,6 +52,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
       - name: Install migrate tool
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Create user

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -1,4 +1,4 @@
-name: Build and deploy services
+name: Database migration tests
 
 on:
   push:
@@ -27,7 +27,7 @@ jobs:
   run-test-db-migrations:
     runs-on: ubuntu-latest
     needs: [detect-code-changes]
-    if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.analyze-code-changes.outputs.ci == 'true' }}
+    if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}
     env:
       USER_PASSWORD: test_password
     steps:

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -28,33 +28,48 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-code-changes]
     if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}
-    env:
-      USER_PASSWORD: test_password
+    # # https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.2"
-      - name: Setup postgresql
-        uses: ikalnytskyi/action-setup-postgres@v7
-        id: postgres
+      # - name: Setup postgresql
+      #   uses: ikalnytskyi/action-setup-postgres@v7
+      #   id: postgres
       - name: Create user
         # https://github.com/ikalnytskyi/action-setup-postgres?tab=readme-ov-file#recommended
         run: |
-          psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
-      - name: Create database
-        run: |
-          psql ${{ steps.postgres.outputs.connection-uri }} -f ./database/test/db_create.sql
-      - name: Install migrate tool
-        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
-      - name: Migrate schema up
-        # https://github.com/actions/runner/issues/1126
-        # https://community.grafana.com/t/grafana-crashes-when-trying-to-connect-to-postgres-panic-setting-pgservicefile-not-supported/46527
-        run: |
-          unset PGSERVICEFILE
-          migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
-      - name: Migrate schema down
-        run: |
-          unset PGSERVICEFILE
-          migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all
+          psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
+
+      #     psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
+      # - name: Create database
+      #   run: |
+      #     psql ${{ steps.postgres.outputs.connection-uri }} -f ./database/test/db_create.sql
+      # - name: Install migrate tool
+      #   run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      # - name: Migrate schema up
+      #   # https://github.com/actions/runner/issues/1126
+      #   # https://community.grafana.com/t/grafana-crashes-when-trying-to-connect-to-postgres-panic-setting-pgservicefile-not-supported/46527
+      #   run: |
+      #     unset PGSERVICEFILE
+      #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
+      # - name: Migrate schema down
+      #   run: |
+      #     unset PGSERVICEFILE
+      #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ci: ${{ steps.filter.outputs.ci }}
-      test-db: ${{ steps.filter.outputs.deployment }}
+      test-db: ${{ steps.filter.outputs.test-db }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -24,7 +24,7 @@ jobs:
               - '.github/workflows/database-migration-tests.yml'
             test-db:
               - 'database/test/**'
-  run-test-db-migrations:
+  validate-test-db:
     runs-on: ubuntu-latest
     needs: [detect-code-changes]
     if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}
@@ -42,6 +42,8 @@ jobs:
       - name: Install migrate tool
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Create user
-        run: ./database/create_user.sh test
+        run: |
+          psql -U postgres postgres -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
       - name: Create database
-        run: ./database/create_database.sh test
+        run: |
+          psql -U postgres postgres -f ./database/test/db_create.sql

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -49,8 +49,12 @@ jobs:
       - name: Install migrate tool
         run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Migrate schema up
+        # https://github.com/actions/runner/issues/1126
+        # https://community.grafana.com/t/grafana-crashes-when-trying-to-connect-to-postgres-panic-setting-pgservicefile-not-supported/46527
         run: |
+          unset PGSERVICEFILE
           migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
       - name: Migrate schema down
         run: |
+          unset PGSERVICEFILE
           migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -66,7 +66,7 @@ jobs:
           psql postgresql://postgres@localhost -f test/db_create.sql
       - name: Migrate schema up
         run: |
-          migrate -path test/migrations -database postgresql://test_user@localhost/test_db up
+          migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable up
       - name: Migrate schema down
         run: |
-          migrate -path test/migrations -database postgresql://test_user@localhost/test_db down -all
+          migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -46,3 +46,11 @@ jobs:
       - name: Create database
         run: |
           psql ${{ steps.postgres.outputs.connection-uri }} -f ./database/test/db_create.sql
+      - name: Install migrate tool
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - name: Migrate schema up
+        run: |
+          migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
+      - name: Migrate schema down
+        run: |
+          migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -45,4 +45,4 @@ jobs:
           psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
       - name: Create database
         run: |
-          psql -U postgres postgres -f ./database/test/db_create.sql
+          psql ${{ steps.postgres.outputs.connection-uri }} -f ./database/test/db_create.sql

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -28,7 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-code-changes]
     if: ${{ needs.detect-code-changes.outputs.test-db == 'true' || needs.detect-code-changes.outputs.ci == 'true' }}
-    # # https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o
+    # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrunworking-directory
+    defaults:
+      run:
+        working-directory: ./database
+    # https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o
     services:
       postgres:
         image: postgres:15
@@ -46,26 +50,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create user
-        working-directory: ./database
         run: |
           psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
         env:
           PGPASSWORD: postgres
           USER_PASSWORD: test_password
-
-      #     psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
-      # - name: Create database
-      #   run: |
-      #     psql ${{ steps.postgres.outputs.connection-uri }} -f ./database/test/db_create.sql
+      - name: Create database
+        run: |
+          psql postgresql://postgres@localhost -f test/db_create.sql
       # - name: Install migrate tool
       #   run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       # - name: Migrate schema up
-      #   # https://github.com/actions/runner/issues/1126
-      #   # https://community.grafana.com/t/grafana-crashes-when-trying-to-connect-to-postgres-panic-setting-pgservicefile-not-supported/46527
       #   run: |
-      #     unset PGSERVICEFILE
       #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} up
       # - name: Migrate schema down
       #   run: |
-      #     unset PGSERVICEFILE
       #     migrate -path database/test/migrations -database ${{ steps.postgres.outputs.connection-uri }} down -all

--- a/.github/workflows/database-migration-tests.yml
+++ b/.github/workflows/database-migration-tests.yml
@@ -45,17 +45,13 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.23.2"
-      # - name: Setup postgresql
-      #   uses: ikalnytskyi/action-setup-postgres@v7
-      #   id: postgres
       - name: Create user
-        # https://github.com/ikalnytskyi/action-setup-postgres?tab=readme-ov-file#recommended
+        working-directory: ./database
         run: |
-          psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
+          psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
+        env:
+          PGPASSWORD: postgres
+          USER_PASSWORD: test_password
 
       #     psql ${{ steps.postgres.outputs.connection-uri }} -v user_password=$USER_PASSWORD -f ./database/test/db_user_create.sql
       # - name: Create database

--- a/database/test/migrations/1_create_initial_schema.down.sql
+++ b/database/test/migrations/1_create_initial_schema.down.sql
@@ -1,0 +1,2 @@
+
+DROP FUNCTION update_updated_at;

--- a/database/test/migrations/1_create_initial_schema.up.sql
+++ b/database/test/migrations/1_create_initial_schema.up.sql
@@ -1,0 +1,12 @@
+
+SET client_encoding = 'UTF8';
+
+SET search_path = test_db_schema, pg_catalog;
+SET default_tablespace = '';
+
+CREATE OR REPLACE FUNCTION update_updated_at() RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+  END;
+$$ language 'plpgsql';

--- a/database/test/migrations/2_create_test_table.down.sql
+++ b/database/test/migrations/2_create_test_table.down.sql
@@ -1,4 +1,4 @@
 
-DROP TRIGGER trigger_my_table_updated_at ON my_table;
+DROP TRIGGER trigger_my_table_updated_at ON my_tables;
 
 DROP TABLE my_table;

--- a/database/test/migrations/2_create_test_table.down.sql
+++ b/database/test/migrations/2_create_test_table.down.sql
@@ -1,0 +1,4 @@
+
+DROP TRIGGER trigger_my_table_updated_at ON my_table;
+
+DROP TABLE my_table;

--- a/database/test/migrations/2_create_test_table.down.sql
+++ b/database/test/migrations/2_create_test_table.down.sql
@@ -1,4 +1,4 @@
 
-DROP TRIGGER trigger_my_table_updated_at ON my_tables;
+DROP TRIGGER trigger_my_table_updated_at ON my_table;
 
 DROP TABLE my_table;

--- a/database/test/migrations/2_create_test_table.up.sql
+++ b/database/test/migrations/2_create_test_table.up.sql
@@ -1,0 +1,14 @@
+
+CREATE TABLE my_table (
+  id UUID NOT NULL,
+  name TEXT NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  version INTEGER DEFAULT 0,
+  PRIMARY KEY (id),
+  UNIQUE (name)
+);
+
+CREATE TRIGGER trigger_my_table_updated_at
+  BEFORE UPDATE OR INSERT ON my_table
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
# Work

As we're managing databases, we want to make sure that the migrations we create can correctly be applied. This allows to guarantee integrity of the data.

## Failed approach

Initially we wanted to follow a similar approach as in [pgx](https://github.com/jackc/pgx/blob/master/.github/workflows/ci.yml#L133). It seemed to work nicely but we hit a roadblock when trying to integrate the `migrate` tool (see [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/11746868221/job/32727541844):

![image](https://github.com/user-attachments/assets/63829f09-1ae8-4156-84ce-88a23118fa12)

After a bit of digging it seems:
* this is [expected](https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/conn.go#L2044)
* requires to unset the [environment variable manually](https://community.grafana.com/t/grafana-crashes-when-trying-to-connect-to-postgres-panic-setting-pgservicefile-not-supported/46527)
* but this is not supported in [github actions](https://github.com/actions/runner/issues/1126)

We tried to manually unset the variable but this seems to break the installation of the postgres server we have (see [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/11747037538/job/32728095189)):

![image](https://github.com/user-attachments/assets/2319ea76-08ff-46a2-98ef-df4d59ef105d)

## Another approach

When reading in the root action it seems like there are other ways to spin up a postgres server to use in actions. A bit of research yielded those two links:
* [post](https://dev.to/techschoolguru/how-to-setup-github-actions-for-go-postgres-to-run-automated-tests-81o) about setting up a CI with postgres
* [this post](https://josef.codes/using-a-real-postgres-database-in-your-github-ci-pipeline/) on how to use the same approach and use `psql` commands.

This seems to rely on [services](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers) containers in github.

With this approach we are able to successfully test the whole migration workflow (see [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/11747729701/job/32730267755)):

![image](https://github.com/user-attachments/assets/21721e45-9d3c-4b7b-b6ab-752de7834a8d)

# Tests

When voluntarily breaking the migrations fails the CI (see [9f2ab38](https://github.com/Knoblauchpilze/user-service/pull/2/commits/9f2ab38358966e9a147664d1bc884fe41aa5f837) and [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/11747788384/job/32730455586)):

![image](https://github.com/user-attachments/assets/8816f2fb-50c2-4879-9888-38400609a3f8)

When fixing it (see [b0d70a3](https://github.com/Knoblauchpilze/user-service/pull/2/commits/b0d70a32a4a9545c3c3473ed145b5ee1b202b638)), the CI works again (see [CI run](https://github.com/Knoblauchpilze/user-service/actions/runs/11747824319/job/32730564310)).

# Future work

N/A.