### PR TITLE
feat: Attempt to migrate the database when running tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -38,12 +38,14 @@ jobs:
         run: |
           psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
           psql postgresql://postgres@localhost -f test/db_create.sql
+        working-directory: ./database
         env:
           PGPASSWORD: postgres
           USER_PASSWORD: test_password
       - name: Migrate schema up
         run: |
           migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable up
+        working-directory: ./database
         env:
           PGPASSWORD: test_password
       - name: Run tests with coverage

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,22 +12,40 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23.2"
-      - name: Setup postgresql
-        uses: ikalnytskyi/action-setup-postgres@v7
-        with:
-          username: test_user
-          password: test_password
-          database: test_db
-          port: 5432
-          postgres-version: "15"
-          ssl: true
-        id: postgres
+      - name: Install migrate tool
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - name: Setup test database
+        run: |
+          psql postgresql://postgres@localhost -v user_password=$USER_PASSWORD -f test/db_user_create.sql
+          psql postgresql://postgres@localhost -f test/db_create.sql
+        env:
+          PGPASSWORD: postgres
+          USER_PASSWORD: test_password
+      - name: Migrate schema up
+        run: |
+          migrate -path test/migrations -database postgresql://test_user@localhost/test_db?sslmode=disable up
+        env:
+          PGPASSWORD: test_password
       - name: Run tests with coverage
         run: go test ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
       - name: Upload coverage to Codecov


### PR DESCRIPTION
# Work

As the project becomes more complex, we will need a bit of test data in the database. This can not be achieved easily with the current approach of using `action-setup-postgres` because we can't use the migrate tool (see #2 for the reason why).

Therefore, we want to migrate to using the same approach as for the DB validation for tests. This PR brings this workflow to life.

# Tests

Running the CI on this branch works as expected:

![image](https://github.com/user-attachments/assets/670675b2-1209-4519-bc55-312e07114013)

# Future work

We could try to separate the tests needing the database and the ones which don't in order to better segregate the usage of resources.
