### PR TITLE
feat: Split tests run between unit and IT

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,23 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.2"
+      - name: Run tests with coverage
+        run: go test -run='^TestUnit_.*' ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          file: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  it-tests:
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:15
@@ -49,7 +66,7 @@ jobs:
         env:
           PGPASSWORD: test_password
       - name: Run tests with coverage
-        run: go test ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
+        run: go test -run='^TestIT_.*' ./... -coverpkg=./... -race -covermode=atomic -coverprofile=coverage.out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/pkg/db/pgx/connection_pool_test.go
+++ b/pkg/db/pgx/connection_pool_test.go
@@ -28,7 +28,7 @@ func TestUnit_New_ValidConnectionString(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestUnit_New_ConnectsToDatabase(t *testing.T) {
+func TestIT_New_ConnectsToDatabase(t *testing.T) {
 	const connStr = "postgres://test_user:test_password@localhost:5432/test_db"
 	pool, err := New(context.Background(), connStr)
 	require.Nil(t, err)


### PR DESCRIPTION
# Work

In this project, some tests are ran against a test database while others are simple unit tests. Up until now all tests are run in the same step which requires to have access to the database: this is not super flexible. Additionally, when we'll have a real service database (for the users), we would have to setup two databases which seems a bit cumbersome.

The goal of this PR is to make it possible to filter tests ran in separate tests based on their requirements. For now this would mean having:
* unit tests, which don't require anything
* integration tests, which require a test database to be available

To achieve this we separated the tests into `TestIT_...` and `TestUnit_...` already in [7dfb387](https://github.com/Knoblauchpilze/user-service/commit/7dfb3876d1617be95f62eb9f324a201b213a72e9).

## Splitting the tests

This behavior is supported by the [go test](https://pkg.go.dev/cmd/go#hdr-Testing_flags) command. What is a bit cumbersome though is that there's not an easy way to to negative matching for the regex provided to `go test`: this seems to be a limitation of the regex engine used by go (see [this post](https://stackoverflow.com/questions/52648425/regex-to-match-strings-that-do-not-start-with-www-in-golang)).

It would be ideal as it would allow to have a step for the IT tests and a step for the rest (i.e. anything not matching the `TestIT_...`. Instead, we currently rely on tests being named either `TestUnit_...` and `TestIT_...`. In the future we could add for example `TestDB_...` for tests that use the users' database.

## Test coverage

As we are running tests from two separate jobs, we also checked that it was possible for codecov to correctly generate the coverage report. According to their [documentation](https://docs.codecov.com/docs/merging-reports) this seems to be supported.

# Tests

The CI in this branch is passing:

![image](https://github.com/user-attachments/assets/70bc4374-01d8-447b-844a-ec13f2dcb79e)

And we seem to get the right code coverage as shown by the comment of the codecov bot.

# Future work

Another possibility would be to rely on some environment variable to select tests. This [post](https://stackoverflow.com/questions/24030059/skip-some-tests-with-go-test) seems to suggest it is possible. It's not clear if it's more readable or not.
