### PR TITLE
feat: Added step to detect wrongly named tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
+          grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,14 +22,11 @@ jobs:
           sed -i 's/func //g' all_tests.txt
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
           FAILURES=$(wc -l < not_matching.txt)
-          echo $FAILURES
-          echo $(cat all_tests.txt)
-          echo $(cat not_matching.txt)
           if [[ ${FAILURES} -ne 0 ]]; then
             echo 'failed=true' >> $GITHUB_OUTPUT
           fi
       - name: Fail if some do not match
-        if: ${{ steps.matching.outputs.failures == 'true' }}
+        if: ${{ steps.matching.outputs.failed == 'true' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
         run: |
           echo "::error ::Detected at least one test not matching the naming convention!"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
-          grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt
+          grep --version
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,6 +18,7 @@ jobs:
         id: matching
         run: |
           grep -rh 'func Test' --include *_test.go > all_tests.txt
+          sed -i 's/func //g' all_tests.txt
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,8 +29,8 @@ jobs:
         if: ${{ steps.matching.outputs.failures == 'true' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
         run: |
-          echo "failures: ${{ steps.matching.outputs.failures }}"
           echo "::error ::Detected at least one test not matching the naming convention!"
+          exit 1
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,6 +22,9 @@ jobs:
           sed -i 's/func //g' all_tests.txt
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
           FAILURES=$(wc -l < not_matching.txt)
+          echo $FAILURES
+          echo $(cat all_tests.txt)
+          echo $(cat not_matching.txt)
           if [[ ${FAILURES} -ne 0 ]]; then
             echo 'failed=true' >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,10 +16,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect tests not matching naming pattern
         id: matching
+        # https://unix.stackexchange.com/questions/330660/preventing-grep-from-causing-premature-termination-of-bash-e-script
         run: |
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
-          grep --version
+          grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
+          echo 'failures=$(wc -l < not_matching.txt)'' >> $GITHUB_OUTPUT
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,9 +21,12 @@ jobs:
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
-          echo 'failures=$(wc -l < not_matching.txt)' >> $GITHUB_OUTPUT
+          FAILURES=$(wc -l < not_matching.txt)
+          if [[ ${FAILURES} -ne 0 ]]; then
+            echo 'failed=true' >> $GITHUB_OUTPUT
+          fi
       - name: Fail if some do not match
-        if: ${{ steps.matching.outputs.failures != 0 }}
+        if: ${{ steps.matching.outputs.failures == 'true' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
         run: |
           echo "failures: ${{ steps.matching.outputs.failures }}"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,8 +10,26 @@ on:
       - "cmd/**"
 
 jobs:
+  check-test-names:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect tests not matching naming pattern
+        id: matching
+        run: |
+          grep -rh 'func Test' --include *_test.go > all_tests.txt
+          sed -i 's/func //g' all_tests.txt
+          grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt
+          echo 'failures=$(wc -l < all_tests.txt)'' >> $GITHUB_OUTPUT
+      - name: Fail if some do not match
+        if: ${{ steps.matching.outputs.failures != '0' }}
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
+        run: |
+          echo "::error ::Detected at least one test not matching the naming convention!"
+
   tests:
     runs-on: ubuntu-latest
+    needs: [check-test-names]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -29,6 +47,7 @@ jobs:
 
   it-tests:
     runs-on: ubuntu-latest
+    needs: [check-test-names]
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
           echo 'failures=$(wc -l < not_matching.txt)' >> $GITHUB_OUTPUT
       - name: Fail if some do not match
-        if: ${{ steps.matching.outputs.failures != '0' }}
+        if: ${{ steps.matching.outputs.failures != 0 }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
         run: |
           echo "failures: ${{ steps.matching.outputs.failures }}"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,6 +26,7 @@ jobs:
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message
         run: |
+          echo "failures: ${{ steps.matching.outputs.failures }}"
           echo "::error ::Detected at least one test not matching the naming convention!"
 
   tests:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,9 +18,6 @@ jobs:
         id: matching
         run: |
           grep -rh 'func Test' --include *_test.go > all_tests.txt
-          sed -i 's/func //g' all_tests.txt
-          grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt
-          echo 'failures=$(wc -l < all_tests.txt)'' >> $GITHUB_OUTPUT
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,6 +21,7 @@ jobs:
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
+          echo 'failures=$(wc -l < not_matching.txt)' >> $GITHUB_OUTPUT
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,6 @@ jobs:
           grep -rh 'func Test' --include *_test.go > all_tests.txt
           sed -i 's/func //g' all_tests.txt
           grep -vE '^Test(Unit|IT)_' all_tests.txt > not_matching.txt || [[ $? == 1 ]]
-          echo 'failures=$(wc -l < not_matching.txt)'' >> $GITHUB_OUTPUT
       - name: Fail if some do not match
         if: ${{ steps.matching.outputs.failures != '0' }}
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-setting-an-error-message

--- a/pkg/repositories/user_repository_test.go
+++ b/pkg/repositories/user_repository_test.go
@@ -160,7 +160,7 @@ func TestIT_UserRepository_Update_WhenVersionIsWrong_ExpectOptimisticLockExcepti
 	assert.True(errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
 }
 
-func TestIT_UserRepository_Update_BumpsUpdatedAt(t *testing.T) {
+func TestITs_UserRepository_Update_BumpsUpdatedAt(t *testing.T) {
 	repo, conn := newTestUserRepository(t)
 
 	user := insertTestUser(t, conn)

--- a/pkg/repositories/user_repository_test.go
+++ b/pkg/repositories/user_repository_test.go
@@ -160,7 +160,7 @@ func TestIT_UserRepository_Update_WhenVersionIsWrong_ExpectOptimisticLockExcepti
 	assert.True(errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
 }
 
-func TestITs_UserRepository_Update_BumpsUpdatedAt(t *testing.T) {
+func TestIT_UserRepository_Update_BumpsUpdatedAt(t *testing.T) {
 	repo, conn := newTestUserRepository(t)
 
 	user := insertTestUser(t, conn)


### PR DESCRIPTION
# Work

In we added two groups of tests:
* `TestUnit_...` defines tests that don't need any dependency to run.
* `TestIT_...` defines tests that need a database or some sort of interactive resources to run.

We separate them into two distinct CI steps so that we only run the needed ones with a database. This introduces a problem though: what if a test does not match any naming convention? Up until this PR, the test would be ignored.

In this PR we add a verification step to check that all the tests are either matching the unit tests' naming convention or the integration tests naming convention. This guarantees that we don't forget running tests by mistake.

# Tests

By voluntarily breaking the naming pattern, we see that the CI correctly detects it:

![image](https://github.com/user-attachments/assets/68726f71-4ce6-48cd-be9f-bf4f7b5c13c1)

When the pattern is followed, the step failing the workflow is skipped:

![image](https://github.com/user-attachments/assets/166f60cf-aa9b-4847-953c-d3be55186d57)

And the CI continues to run the tests:

![image](https://github.com/user-attachments/assets/0b307c28-b9fa-4a4a-bc50-91566e87c1e7)

# Future work

N/A.
