### PR TITLE
feat: Attempt to push the updated tag to the ec2-deployment repository

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -281,5 +281,5 @@ jobs:
           git pull
           git config --global user.name 'totocorpbot'
           git config --global user.email 'totocorpbot@users.noreply.github.com'
-          git commit -am "infra: Bumped user-service version to latest revision"
+          git commit -am "infra: Bumped user-service version to ${{ needs.extract-service-tag.outputs.version }}"
           git push

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -266,6 +266,7 @@ jobs:
   update-deployment:
     runs-on: ubuntu-latest
     needs: [extract-service-tag, e2e-tests]
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -262,3 +262,21 @@ jobs:
             echo "::error ::Expected http response to match expected syntax but it did not: ${{ steps.test-results.outputs.response_body }}!"
             exit 1
           fi
+
+  update-deployment:
+    runs-on: ubuntu-latest
+    needs: [extract-service-tag, build-and-push-docker-image]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: "ec2-deployment"
+      - name: Update service tag
+        run: |
+          echo "${{ needs.extract-service-tag.outputs.version }}" > ./build/user-service/version.txt
+      - name: "Commit changes"
+        run: |
+          git pull
+          git config --global user.name 'totocorpbot'
+          git config --global user.email 'totocorpbot@users.noreply.github.com'
+          git commit -am "infra: Bumped user-service version to latest revision"
+          git push

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -270,6 +270,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "Knoblauchpilze/ec2-deployment"
+          # https://stackoverflow.com/questions/64374179/how-to-push-to-another-repository-in-github-actions
           token: ${{ secrets.DEPLOYMENT_TOKEN }}
       - name: Update service tag
         run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -266,7 +266,6 @@ jobs:
   update-deployment:
     runs-on: ubuntu-latest
     needs: [extract-service-tag, e2e-tests]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -274,7 +274,7 @@ jobs:
           token: ${{ secrets.DEPLOYMENT_TOKEN }}
       - name: Update service tag
         run: |
-          echo "2fe5027" > ./build/user-service/version.txt
+          echo "${{ needs.extract-service-tag.outputs.version }}" > ./build/user-service/version.txt
       - name: "Commit changes"
         run: |
           git pull

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -269,7 +269,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: "ec2-deployment"
+          repository: "Knoblauchpilze/ec2-deployment"
       - name: Update service tag
         run: |
           echo "${{ needs.extract-service-tag.outputs.version }}" > ./build/user-service/version.txt

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -265,7 +265,7 @@ jobs:
 
   update-deployment:
     runs-on: ubuntu-latest
-    #needs: [extract-service-tag, build-and-push-docker-image]
+    needs: [extract-service-tag, e2e-tests]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -270,6 +270,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "Knoblauchpilze/ec2-deployment"
+          token: ${{ secrets.DEPLOYMENT_TOKEN }}
       - name: Update service tag
         run: |
           echo "2fe5027" > ./build/user-service/version.txt

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -265,14 +265,14 @@ jobs:
 
   update-deployment:
     runs-on: ubuntu-latest
-    needs: [extract-service-tag, build-and-push-docker-image]
+    #needs: [extract-service-tag, build-and-push-docker-image]
     steps:
       - uses: actions/checkout@v4
         with:
           repository: "Knoblauchpilze/ec2-deployment"
       - name: Update service tag
         run: |
-          echo "${{ needs.extract-service-tag.outputs.version }}" > ./build/user-service/version.txt
+          echo "2fe5027" > ./build/user-service/version.txt
       - name: "Commit changes"
         run: |
           git pull


### PR DESCRIPTION
# Work

## Context
In order to make the deployment of the cluster of services we have running on the EC2 instance hosting the [Galactic Sovereign](https://github.com/Knoblauchpilze/galactic-sovereign) website, we extracted a dedicated deployment repository over at [ec2-deployment](https://github.com/Knoblauchpilze/ec2-deployment).

This repository is supposed to handle the deployment and keep the secretes and the logic to access the instance in a single place. This allows to also move away from the monorepo approach we followed so far.

## What needs to be changed?
As opposed to the monorepo strategy, we now have to communicate from each individual repository (in this case the `user-service`) to the `ec2-deployment` that a new version of the service is available and which one it is.

The approach we want to follow is to have:
* a `build` folder in the `ec2-deployment` which contains the versions of the service to deploy.
* a step in the CI of this repository to push the new version when all checks have succeeded.
* this will trigger the deployment workflow in the `ec2-deployment` project.

# Tests

For testing purposes we activated the push on a feature branch. The CI detects it and creates a commit in the [ec2-deployment](https://github.com/Knoblauchpilze/ec2-deployment) repository:

![image](https://github.com/user-attachments/assets/20ba11e8-6720-4733-8d79-d2b011140b86)

![image](https://github.com/user-attachments/assets/3b2b86fa-5e09-4eb1-bc7e-8a5dc25791ae)

This also correctly triggers the workflow to deploy those changes to the remote EC2 instance:

![image](https://github.com/user-attachments/assets/7258cec8-5297-4e64-aeaa-72426303b3c9)

In reality we only want to push to the `ec2-deployment` when the workflow in this repository happens on the `master` branch. This is accomplished by [138b9ef](https://github.com/Knoblauchpilze/user-service/pull/8/commits/138b9efdd52d4fe7dbc972c38456be79af281b05):

![image](https://github.com/user-attachments/assets/29288481-04de-4382-9ace-c635cfb5f9bc)

# Future work

N/A.
