### PR TITLE
feat: Do not upload code coverage when dependabot is the actor

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -146,10 +146,10 @@ jobs:
           context: .
           file: ./build/user-service/Dockerfile
           build-args: GIT_COMMIT_HASH=${{ needs.extract-service-tag.outputs.version }}
-          push: true
+          push: ${{ github.actor == 'dependabot[bot]' }}
           tags: totocorpsoftwareinc/user-service:${{ needs.extract-service-tag.outputs.version }}
       - name: Save image as artifact
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         # https://stackoverflow.com/questions/23935141/how-to-copy-docker-images-from-one-host-to-another-without-using-a-repository
         run: |
           docker save -o /tmp/user-service.tar totocorpsoftwareinc/user-service:${{ needs.extract-service-tag.outputs.version }}


### PR DESCRIPTION
# Work

## Context

In #9 we noticed that the CI fails when `dependabot` opens a PR and triggers a workflow. This seems to be due to [this issue](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544). There are several recommendations to move forward:
* add a second workflow for `dependabot` with similar permissions as before.
* modify the workflow to trigger a second one which then has the permissions.
* modify the workflow to not need the permissions for `dependabot`.
 
The third option is not really part of the recommendation, but in our case it seems to be easy to do.

:information_source: **Note:** it's not 100% clear if this applies to us as the issue mentions a `pull_request` target, while we have a workflow that uses `push`. Also we don't have any problems in the [galactic-sovereign](https://github.com/Knoblauchpilze/galactic-sovereign) project and the syntax we use is (at first glance) exactly the same.

## How to solve the problem?

We want to not require secrets to run a `dependabot` workflow. The secrets are (at the moment) mainly used in two locations:
* to push the code coverage to `codecov`.
* to push/download docker image of the service between steps.

In the case of `dependabot`, we can easily disable code coverage upload. This will still allow to run the tests but we don't expect anything to change in the coverage due to an update to dependencies.

In regards to push/pull the docker image, we also have a workaround:
* we can disable pushing the image for such branches: it's unlikely that we will use the result of a branch.
* we can use [artifacts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) to transfer the image from one job to the next.

The second point proved a bit more difficult than anticipated. This example from the [official documentation](https://docs.docker.com/build/ci/github-actions/share-image-jobs/) does not seem to work. We are met with the following error:

![image](https://github.com/user-attachments/assets/dbc7ddfb-e62d-46c6-9dfc-54c0bbfc2f7e)

We can reproduce this behavior locally. Multiple other solutions recommend to use another output type (see [here](https://github.com/docker/build-push-action/issues/225)) for example but this failed in a similar way.

What could work is to follow what was explained in this [stackoverflow](https://stackoverflow.com/questions/23935141/how-to-copy-docker-images-from-one-host-to-another-without-using-a-repository) post.

**Update:** it seems it does not. Or rather, we are facing issues later on with the E2E tests step where it seems we don't correctly manage to start the docker image. The part about uploading/downloading artifacts seems to work.

# Tests

# Future work

It's not entirely clear why this works for the `galactic-sovereign` project. We have a similar situation of a workflow triggered by `dependabot` which uses secrets. This would be worth it to understand if there are any differences.
